### PR TITLE
Automatic handling of positive polarity

### DIFF
--- a/tpx3/analysis.py
+++ b/tpx3/analysis.py
@@ -8,9 +8,9 @@
 '''
     Script to convert raw data
 '''
-import print_function
-import absolute_import
-import division
+from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import division
 import numpy as np
 from basil.utils.BitLogic import BitLogic
 import logging

--- a/tpx3/scans/EqualisationCharge.py
+++ b/tpx3/scans/EqualisationCharge.py
@@ -271,13 +271,16 @@ class EqualisationCharge(ScanBase):
             scurve_th15 = analysis.scurve_hist(hit_data_thr15, np.arange(len(param_range) // 2, len(param_range)))
             hit_data_thr15 = None
 
+            # Get the polarity to spcify if s or z curve is fitted
+            neg_polarity = [int(item[1]) for item in general_config if item[0] == b'Polarity'][0] == 1
+
             # Fit S-Curves to the histograms for all pixels
             self.logger.info('Fit the scurves for all pixels...')
-            thr2D_th0, sig2D_th0, chi2ndf2D_th0 = analysis.fit_scurves_multithread(scurve_th0, scan_param_range=list(range(Vthreshold_start, Vthreshold_stop + 1)), n_injections=n_injections, invert_x=True, progress = progress)
+            thr2D_th0, sig2D_th0, chi2ndf2D_th0 = analysis.fit_scurves_multithread(scurve_th0, scan_param_range=list(range(Vthreshold_start, Vthreshold_stop + 1)), n_injections=n_injections, invert_x=neg_polarity, progress = progress)
             h5_file.create_carray(h5_file.root.interpreted, name='HistSCurve_th0', obj=scurve_th0)
             h5_file.create_carray(h5_file.root.interpreted, name='ThresholdMap_th0', obj=thr2D_th0.T)
             scurve_th0 = None
-            thr2D_th15, sig2D_th15, chi2ndf2D_th15 = analysis.fit_scurves_multithread(scurve_th15, scan_param_range=list(range(Vthreshold_start, Vthreshold_stop + 1)), n_injections=n_injections, invert_x=True, progress = progress)
+            thr2D_th15, sig2D_th15, chi2ndf2D_th15 = analysis.fit_scurves_multithread(scurve_th15, scan_param_range=list(range(Vthreshold_start, Vthreshold_stop + 1)), n_injections=n_injections, invert_x=neg_polarity, progress = progress)
             h5_file.create_carray(h5_file.root.interpreted, name='HistSCurve_th15', obj=scurve_th15)
             h5_file.create_carray(h5_file.root.interpreted, name='ThresholdMap_th15', obj=thr2D_th15.T)
             scurve_th15 = None

--- a/tpx3/scans/PixelDACopt.py
+++ b/tpx3/scans/PixelDACopt.py
@@ -359,13 +359,16 @@ class PixelDACopt(ScanBase):
             scurve_th15 = analysis.scurve_hist(hit_data_thr15, np.arange(len(param_range) // 2, len(param_range)))
             hit_data_thr15 = None
 
+            # Get the polarity to specifiy if s or z curve is fitted
+            neg_polarity = [int(item[1]) for item in general_config if item[0] == b'Polarity'][0] == 1
+
             # Fit S-Curves to the histograms for all pixels
             self.logger.info('Fit the scurves for all pixels...')
-            thr2D_th0, _, _ = analysis.fit_scurves_multithread(scurve_th0, scan_param_range=list(range(Vthreshold_start, Vthreshold_stop + 1)), n_injections=n_injections, invert_x=True, progress = progress)
+            thr2D_th0, _, _ = analysis.fit_scurves_multithread(scurve_th0, scan_param_range=list(range(Vthreshold_start, Vthreshold_stop + 1)), n_injections=n_injections, invert_x=neg_polarity, progress = progress)
             h5_file.create_carray(h5_file.root.interpreted, name='HistSCurve_th0_' + str(iteration), obj=scurve_th0)
             h5_file.create_carray(h5_file.root.interpreted, name='ThresholdMap_th0_' + str(iteration), obj=thr2D_th0.T)
             scurve_th0 = None
-            thr2D_th15, _, _ = analysis.fit_scurves_multithread(scurve_th15, scan_param_range=list(range(Vthreshold_start, Vthreshold_stop + 1)), n_injections=n_injections, invert_x=True, progress = progress)
+            thr2D_th15, _, _ = analysis.fit_scurves_multithread(scurve_th15, scan_param_range=list(range(Vthreshold_start, Vthreshold_stop + 1)), n_injections=n_injections, invert_x=neg_polarity, progress = progress)
             h5_file.create_carray(h5_file.root.interpreted, name='HistSCurve_th15_' + str(iteration), obj=scurve_th15)
             h5_file.create_carray(h5_file.root.interpreted, name='ThresholdMap_th15_' + str(iteration) , obj=thr2D_th15.T)
             scurve_th15 = None

--- a/tpx3/scans/TestpulseScan.py
+++ b/tpx3/scans/TestpulseScan.py
@@ -185,10 +185,11 @@ class TestpulseScan(ScanBase):
             n_injections = [int(item[1]) for item in run_config if item[0] == b'n_injections'][0]
             VTP_fine_start = [int(item[1]) for item in run_config if item[0] == b'VTP_fine_start'][0]
             VTP_fine_stop = [int(item[1]) for item in run_config if item[0] == b'VTP_fine_stop'][0]
+            neg_polarity = [int(item[1]) for item in general_config if item[0] == b'Polarity'][0] == 1
 
             # Fit S-Curves to the histograms for all pixels
             param_range = list(range(VTP_fine_start, VTP_fine_stop))
-            thr2D, sig2D, chi2ndf2D = analysis.fit_scurves_multithread(scurve, scan_param_range=param_range, n_injections=n_injections, progress = progress)
+            thr2D, sig2D, chi2ndf2D = analysis.fit_scurves_multithread(scurve, scan_param_range=param_range, n_injections=n_injections, progress = progress, invert_x=not neg_polarity)
 
             h5_file.create_carray(h5_file.root.interpreted, name='HistSCurve', obj=scurve)
             h5_file.create_carray(h5_file.root.interpreted, name='Chi2Map', obj=chi2ndf2D.T)

--- a/tpx3/scans/ThresholdCalib.py
+++ b/tpx3/scans/ThresholdCalib.py
@@ -237,10 +237,11 @@ class ThresholdCalib(ScanBase):
             n_injections = [int(item[1]) for item in run_config if item[0] == b'n_injections'][0]
             Vthreshold_start = [int(item[1]) for item in run_config if item[0] == b'Vthreshold_start'][0]
             Vthreshold_stop = [int(item[1]) for item in run_config if item[0] == b'Vthreshold_stop'][0]
+            neg_polarity = [int(item[1]) for item in general_config if item[0] == b'Polarity'][0] == 1
 
             # Fit S-Curves to the histograms for all pixels
             param_range = list(range(Vthreshold_start, Vthreshold_stop + 1))
-            thr2D, sig2D, chi2ndf2D = analysis.fit_scurves_multithread(scurve, scan_param_range=param_range, n_injections=n_injections, invert_x=True, progress = progress)
+            thr2D, sig2D, chi2ndf2D = analysis.fit_scurves_multithread(scurve, scan_param_range=param_range, n_injections=n_injections, invert_x=neg_polarity, progress = progress)
 
             h5_file.create_carray(eval(interpreted_call), name='HistSCurve', obj=scurve)
             h5_file.create_carray(eval(interpreted_call), name='Chi2Map', obj=chi2ndf2D.T)

--- a/tpx3/scans/ThresholdScan.py
+++ b/tpx3/scans/ThresholdScan.py
@@ -159,6 +159,12 @@ class ThresholdScan(ScanBase):
             op_mode = [row[1] for row in general_config if row[0]==b'Op_mode'][0]
             vco = [row[1] for row in general_config if row[0]==b'Fast_Io_en'][0]
 
+
+            # Create group to save all data and histograms to the HDF file
+            try:
+                h5_file.remove_node(h5_file.root.interpreted, recursive=True)
+            except:
+                pass
             # Create group to save all data and histograms to the HDF file
             h5_file.create_group(h5_file.root, 'interpreted', 'Interpreted Data')
 
@@ -186,10 +192,11 @@ class ThresholdScan(ScanBase):
             n_injections = [int(item[1]) for item in run_config if item[0] == b'n_injections'][0]
             Vthreshold_start = [int(item[1]) for item in run_config if item[0] == b'Vthreshold_start'][0]
             Vthreshold_stop = [int(item[1]) for item in run_config if item[0] == b'Vthreshold_stop'][0]
+            neg_polarity = [int(item[1]) for item in general_config if item[0] == b'Polarity'][0] == 1
 
             # Fit S-Curves to the histograms for all pixels
             param_range = list(range(Vthreshold_start, Vthreshold_stop + 1))
-            thr2D, sig2D, chi2ndf2D = analysis.fit_scurves_multithread(scurve, scan_param_range=param_range, n_injections=n_injections, invert_x=True, progress = progress)
+            thr2D, sig2D, chi2ndf2D = analysis.fit_scurves_multithread(scurve, scan_param_range=param_range, n_injections=n_injections, invert_x=neg_polarity, progress = progress)
 
             h5_file.create_carray(h5_file.root.interpreted, name='HistSCurve', obj=scurve)
             h5_file.create_carray(h5_file.root.interpreted, name='Chi2Map', obj=chi2ndf2D.T)


### PR DESCRIPTION
The fits of the scans choose now whether to fit a Z or S curve depending on the polarity. For negative polarities (from the general configuration) the `invert_x` of the fits is set, except for the Testpulse Scan, where everything is the other way around.